### PR TITLE
Updates plugin with helpful failure log and messages for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ buildscript {
  
         dependencies {
                 classpath 'com.android.tools.build:gradle:0.12+'
-                classpath group: 'org.testobject', name: 'testobject-gradle-plugin', version: '0.0.24'
+                classpath group: 'org.testobject', name: 'testobject-gradle-plugin', version: '0.0.29'
         }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.testobject</groupId>
 	<artifactId>testobject-gradle-plugin</artifactId>
-	<version>0.0.25</version>
+	<version>0.0.27</version>
 	<name>TestObject Gradle Plugin</name>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,15 +3,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.testobject</groupId>
 	<artifactId>testobject-gradle-plugin</artifactId>
-	<version>0.0.28-4</version>
+	<version>0.0.29</version>
 	<name>TestObject Gradle Plugin</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<releaseRepoUrl>http://repo.ad.corp.expertcity.com:8080/archiva/repository/internal/</releaseRepoUrl>
-        <snapshotRepoUrl>http://repo.ad.corp.expertcity.com:8080/archiva/repository/snapshots/</snapshotRepoUrl>
-        <deployRepoUrl>${releaseRepoUrl}</deployRepoUrl>
-	</properties>
+    </properties>
 
 	<build>
 		<plugins>
@@ -71,7 +68,7 @@
 		<tag>HEAD</tag>
 	</scm>
 
-<!-- 	<distributionManagement>
+	<distributionManagement>
 		<repository>
 			<id>testobject-public-repo</id>
 			<url>http://nexus.testobject.org/nexus/content/repositories/testobject-public-repo</url>
@@ -81,20 +78,6 @@
 			<url>http://nexus.testobject.org/nexus/content/repositories/testobject-public-snapshots</url>
 		</snapshotRepository>
 	</distributionManagement>
- -->
-
-  <distributionManagement>
-        <repository>
-            <id>Repository Archiva Managed Internal Repository</id>
-            <name>Repository Archiva Managed Internal Repository</name>
-            <url>${releaseRepoUrl}</url>
-        </repository>
-        <snapshotRepository>
-            <id>Repository Archiva Managed Snapshot Repository</id>
-            <name>Repository Archiva Managed Snapshot Repository</name>
-            <url>${snapshotRepoUrl}</url>
-        </snapshotRepository>
-    </distributionManagement>
 
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.testobject</groupId>
 	<artifactId>testobject-gradle-plugin</artifactId>
-	<version>0.0.27</version>
+	<version>0.0.28-4</version>
 	<name>TestObject Gradle Plugin</name>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,14 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.testobject</groupId>
 	<artifactId>testobject-gradle-plugin</artifactId>
-	<version>0.0.24</version>
+	<version>0.0.25</version>
 	<name>TestObject Gradle Plugin</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<releaseRepoUrl>http://repo.ad.corp.expertcity.com:8080/archiva/repository/internal/</releaseRepoUrl>
+        <snapshotRepoUrl>http://repo.ad.corp.expertcity.com:8080/archiva/repository/snapshots/</snapshotRepoUrl>
+        <deployRepoUrl>${releaseRepoUrl}</deployRepoUrl>
 	</properties>
 
 	<build>
@@ -68,7 +71,7 @@
 		<tag>HEAD</tag>
 	</scm>
 
-	<distributionManagement>
+<!-- 	<distributionManagement>
 		<repository>
 			<id>testobject-public-repo</id>
 			<url>http://nexus.testobject.org/nexus/content/repositories/testobject-public-repo</url>
@@ -78,6 +81,20 @@
 			<url>http://nexus.testobject.org/nexus/content/repositories/testobject-public-snapshots</url>
 		</snapshotRepository>
 	</distributionManagement>
+ -->
+
+  <distributionManagement>
+        <repository>
+            <id>Repository Archiva Managed Internal Repository</id>
+            <name>Repository Archiva Managed Internal Repository</name>
+            <url>${releaseRepoUrl}</url>
+        </repository>
+        <snapshotRepository>
+            <id>Repository Archiva Managed Snapshot Repository</id>
+            <name>Repository Archiva Managed Snapshot Repository</name>
+            <url>${snapshotRepoUrl}</url>
+        </snapshotRepository>
+    </distributionManagement>
 
 	<dependencies>
 		<dependency>

--- a/src/main/java/org/testobject/gradle/TestObjectTestServer.java
+++ b/src/main/java/org/testobject/gradle/TestObjectTestServer.java
@@ -1,6 +1,9 @@
 package org.testobject.gradle;
 
 import java.io.File;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.concurrent.TimeUnit;
 import java.util.Iterator;
 
 import org.gradle.api.GradleScriptException;
@@ -34,25 +37,52 @@ public class TestObjectTestServer extends TestServer {
         String app = extension.getApp();
         Long testSuite = extension.getTestSuite();
 
+
         login(client, username, password);
 
         updateInstrumentationSuite(testApk, appAk, client, username, app, testSuite);
+
+        long start = System.currentTimeMillis();
+
         long suiteReportId = client.startInstrumentationTestSuite(username, app, testSuite);
 
         TestSuiteReport suiteReport = client.waitForSuiteReport(username, app, suiteReportId);
+
+        long end = System.currentTimeMillis();
+
+
+        String executionTime = getExecutionTime(start , end);
+
         int errors = countErrors(suiteReport);
         String downloadURL = String.format("%s/users/%s/projects/%s/automationReports/%d/download/zip", baseUrl, username, app, suiteReportId);
         String reportURL = String.format("%s/#/%s/%s/espresso/%d/reports/%d" , baseUrl.replace("/api/rest" , ""), username , app, testSuite , suiteReportId);
-        String msg = String.format("Test suite report '%d' finished with status: '%s' , tests: %d , errors: %d , " +
-                "\n DownloadZIPURL: %s " +
-                "\n ReportURL : %s", suiteReportId, suiteReport.getStatus(), suiteReport
-                .getReports().size(), errors, downloadURL , reportURL);
+
+        StringBuilder msg = new StringBuilder();
+        msg.append("\n");
+        msg.append(getTestsList(suiteReport , reportURL));
+        msg.append("----------------------------------------------------------------------------------");
+        msg.append("\n");
+        msg.append(String.format("Ran %d tests in %s" , suiteReport
+                .getReports().size() , executionTime ));
+        msg.append("\n");
+        msg.append(suiteReport.getStatus());
+        msg.append("\n");
+
+        if(errors > 0){
+            msg.append(String.format("List of failed Test (Total errors : %d)", errors));
+            msg.append("\n");
+            msg.append(failedTestsList(suiteReport , reportURL));
+            msg.append("\n");
+        }
+
+        msg.append(String.format("DownloadZIP URL: '%s'" , downloadURL));
+        msg.append("\n");
+        msg.append(String.format("Report URL : '%s'" , reportURL));
         if (errors == 0) {
-            logger.info(msg);
+            logger.info(msg.toString());
         } else {
-            logger.error(msg);
             if (extension.getFailOnError()) {
-                throw new GradleScriptException("failure during test suite execution of test suite " + testSuite, new Exception(msg));
+                throw new GradleScriptException("failure during test suite execution of test suite " + testSuite, new Exception(msg.toString()));
             }
         }
     }
@@ -68,6 +98,7 @@ public class TestObjectTestServer extends TestServer {
 	private void updateInstrumentationSuite(File testApk, File appAk, TestObjectClient client, String username, String app, Long testSuite) {
 		try {
 			client.updateInstrumentationTestSuite(username, app, testSuite, appAk, testApk);
+            logger.info(String.format("Uploaded appAPK : %s and testAPK : %s" , appAk.getAbsolutePath() , testApk.getAbsolutePath()));
 		} catch (Exception e) {
 			throw new GradleScriptException(String.format("unable to update testSuite %s", testSuite), e);
 		}
@@ -84,6 +115,47 @@ public class TestObjectTestServer extends TestServer {
 		}
 		return errors;
 	}
+
+    private static String getTestsList(TestSuiteReport suiteReport , String  baseReportUrl) {
+        StringBuilder list = new StringBuilder();
+        Iterator<TestSuiteReport.ReportEntry> reportsIterator = suiteReport.getReports().iterator();
+        while (reportsIterator.hasNext()) {
+            TestSuiteReport.ReportEntry reportEntry = (TestSuiteReport.ReportEntry) reportsIterator.next();
+            String testName = getTestName(suiteReport , reportEntry.getKey().getTestId());
+            String deviceId = reportEntry.getKey().getDeviceId();
+            list.append(String.format("%s - %s .............  %s" , testName , deviceId , reportEntry.getView().getStatus().toString()));
+            list.append("\n");
+        }
+        return list.toString();
+    }
+
+    private static String failedTestsList(TestSuiteReport suiteReport , String  baseReportUrl) {
+        StringBuilder list = new StringBuilder();
+        Iterator<TestSuiteReport.ReportEntry> reportsIterator = suiteReport.getReports().iterator();
+        while (reportsIterator.hasNext()) {
+            TestSuiteReport.ReportEntry reportEntry = (TestSuiteReport.ReportEntry) reportsIterator.next();
+            if (reportEntry.getView().getStatus() == TestSuiteReport.Status.FAILURE) {
+                String testName = getTestName(suiteReport , reportEntry.getKey().getTestId());
+                String deviceId = reportEntry.getKey().getDeviceId();
+                String url = String.format("%s/executions/%d" ,
+                        baseReportUrl , reportEntry.getView().getReportId()); 
+                list.append(String.format("%s - %s ....  %s" , testName , deviceId , url));
+                list.append("\n");
+            }
+        }
+        return list.toString();
+    }
+
+    private static String getTestName(TestSuiteReport suiteReport , long testId) {
+        Iterator<TestSuiteReport.TestView> testViewIterator = suiteReport.getTests().iterator();
+        while (testViewIterator.hasNext()) {
+            TestSuiteReport.TestView testView = (TestSuiteReport.TestView) testViewIterator.next();
+            if (testView.getTestId() == testId) {
+                return testView.getName();
+            }
+        }
+        return "";
+    }
 
 	@Override
 	public boolean isConfigured() {
@@ -121,5 +193,25 @@ public class TestObjectTestServer extends TestServer {
 		return proxyHost != null ? new TestObjectClient.ProxySettings(proxyHost, Integer.parseInt(proxyPort), proxyUser, proxyPassword)
 				: null;
 	}
+
+    /**
+     * get Formatted Execution Time for printing
+     * @param start
+     * @param end
+     * @return
+     */
+    private static String getExecutionTime(final long start, final long end) {
+        NumberFormat formatter = new DecimalFormat("#.000");
+        long millis = end - start;
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(millis);
+        String seconds = formatter.format(millis / 1000d);
+        String executionTime;
+        if (minutes > 0) {
+            executionTime = String.format("%dm (%ss)", minutes, seconds);
+        } else {
+            executionTime = String.format("%ss", seconds);
+        }
+        return executionTime;
+    }
 
 }

--- a/src/main/java/org/testobject/gradle/TestObjectTestServer.java
+++ b/src/main/java/org/testobject/gradle/TestObjectTestServer.java
@@ -25,7 +25,7 @@ public class TestObjectTestServer extends TestServer {
 	@Override
 	public void uploadApks(@NonNull String variantName, @NonNull File testApk, @Nullable File appAk) {
 		String baseUrl = extension.getBaseUrl();
-		logger.info("using baseUrl '%s'", baseUrl);
+		logger.info(String.format("using baseUrl '%s'", baseUrl));
 
 		TestObjectClient client = TestObjectClient.Factory.create(baseUrl, getProxySettings());
 
@@ -41,9 +41,9 @@ public class TestObjectTestServer extends TestServer {
 
 		TestSuiteReport suiteReport = client.waitForSuiteReport(username, app, suiteReportId);
 		int errors = countErrors(suiteReport);
-
-		String msg = String.format("test suite report %d finished with status: %s tests: %d errors: %d", suiteReportId, suiteReport.getStatus(), suiteReport
-				.getReports().size(), errors);
+		String downloadURL = String.format("https://citrix.testobject.com/api/rest/users/%s/projects/%s/automationReports/%d/download/zip" , username , app , suiteReportId);
+		String msg = String.format("test suite report %d finished with status: %s tests: %d errors: %d ReportDownloadURL : %s ", suiteReportId, suiteReport.getStatus(), suiteReport
+				.getReports().size(), errors , downloadURL);
 		if (errors == 0) {
 			logger.info(msg);
 		} else {
@@ -57,7 +57,7 @@ public class TestObjectTestServer extends TestServer {
 	private void login(TestObjectClient client, String username, String password) {
 		try {
 			client.login(username, password);
-			logger.info("user %s successfully logged in", username);
+			logger.info(String.format("user %s successfully logged in", username));
 		} catch (Exception e) {
 			throw new GradleScriptException(String.format("unable to login user %s", username), e);
 		}


### PR DESCRIPTION
Console output from gradle plugin looks like this when gradle option --info is used.
user 'citrix' successfully logged in
Uploaded appAPK : /home/ec2-user/workspace/Communication_Cloud/GoToMeeting/Android/endpoint-cloudtests/mobile/build/outputs/apk/mobile-debug.apk and testAPK : /home/ec2-user/workspace/Communication_Cloud/GoToMeeting/Android/endpoint-cloudtests/mobile/build/outputs/apk/mobile-debug-androidTest-unaligned.apk

testJoinWithoutName - HTC_Nexus_9_real_private .............  SUCCESS
testJoinWithoutName - Samsung_Galaxy_Note_3_real_private .............  SUCCESS
testInternalServerError - HTC_Nexus_9_real_private .............  SUCCESS
testInternalServerError - Samsung_Galaxy_Note_3_real_private .............  SUCCESS

---

Ran 4 tests in 6m (394.615s)
SUCCESS
DownloadZIP URL: 'https://citrix.testobject.com/api/rest/users/citrix/projects/gotomeeting-v2/automationReports/23/download/zip'
Report URL : 'https://citrix.testobject.com/#/citrix/gotomeeting-v2/espresso/10/reports/23'
:mobile:testobjectUpload (Thread[Task worker,5,main]) completed. Took 6 mins 55.864 secs.
:mobile:runCloudTestsInCI (Thread[Task worker,5,main]) started.
:mobile:runCloudTestsInCI
Skipping task ':mobile:runCloudTestsInCI' as it has no actions.
:mobile:runCloudTestsInCI (Thread[Task worker,5,main]) completed. Took 0.001 secs.
