### PR TITLE
MRDC-292 Deprecate testobject-gradle-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 testobject-gradle-plugin
 ===================
+Deprecated
+----------
+This tool has been deprecated. Please use the [espresso-runner](https://github.com/testobject/espresso-runner) tool instead.
 
 Build instructions
 ------------------

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-testobject-gradle-plugin
-===================
 Deprecated
-----------
+==========
 This tool has been deprecated. Please use the [espresso-runner](https://github.com/testobject/espresso-runner) tool instead.
+
+testobject-gradle-plugin
+-----------------------
 
 Build instructions
 ------------------


### PR DESCRIPTION
testobject-gradle-plugin is being deprecated in favor of the [espresso-runner](https://github.com/testobject/espresso-runner)